### PR TITLE
Add threaded command worker implementation with start/stop commands and tests

### DIFF
--- a/src/commands/tests_threading.zig
+++ b/src/commands/tests_threading.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const testing = std.testing;
+const t = @import("../utils/tests/helpers.zig");
+const core = @import("core.zig");
+const handlers = @import("handlers.zig");
+const threading = @import("threading.zig");
+
+const CommandQueue = core.CommandQueue;
+const CommandFactory = core.CommandFactory;
+
+// Simple command that sleeps for a short time and increments a shared counter
+const SleepIncCtx = struct { counter: *usize, ns: u64 };
+fn execSleepInc(ctx: *SleepIncCtx, _: *CommandQueue) !void {
+    std.time.sleep(ctx.ns);
+    ctx.counter.* += 1;
+}
+
+// A no-op command for use in tests
+const NoopCtx = struct {};
+fn execNoop(_: *NoopCtx, _: *CommandQueue) !void { return; }
+
+// Helper to drain a simple queue of commands by executing them directly (single-threaded)
+fn runQueue(q: *CommandQueue) void {
+    while (q.popFront()) |cmd| {
+        cmd.call(cmd.ctx, q) catch {};
+        if (cmd.drop) |d| d(cmd.ctx, q.allocator);
+    }
+}
+
+test "Threading: start command starts worker" {
+    t.tprint("Threading start test\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+
+    var sctx = threading.StartCtx{ .worker = &w };
+    const c = threading.ThreadingFactory.StartCommand(&sctx);
+    try q.pushBack(c);
+
+    // Run start command in the main test thread via handlers/process-like loop
+    runQueue(&q);
+
+    // Wait until the worker signals it's started
+    w.waitStarted();
+
+    // Validate that the thread handle exists (started)
+    try testing.expect(w.thread != null);
+}
+
+test "Threading: hard stop stops without draining remaining tasks" {
+    t.tprint("Threading hard stop test\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    // Start worker via command
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+    var sctx = threading.StartCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.StartCommand(&sctx));
+    runQueue(&q);
+    w.waitStarted();
+
+    // Enqueue several tasks
+    var counter: usize = 0;
+    const Maker = CommandFactory(SleepIncCtx, execSleepInc);
+    const per_ns: u64 = 2_000_000; // 2 ms
+    const total: usize = 10;
+    var i: usize = 0;
+    while (i < total) : (i += 1) {
+        const ctx = SleepIncCtx{ .counter = &counter, .ns = per_ns };
+        // allocate owned context to avoid stack pointer lifetime issues
+        const heap_ctx = try alloc.create(SleepIncCtx);
+        heap_ctx.* = ctx;
+        const cmd = Maker.makeOwned(heap_ctx, .flaky, false, false);
+        w.enqueue(cmd);
+    }
+
+    // Issue hard stop via command and wait for join
+    var hctx = threading.HardStopCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.HardStopCommand(&hctx));
+    runQueue(&q);
+
+    // After hard stop, the thread should be joined and some tasks likely left unprocessed
+    try testing.expect(w.thread == null);
+    try testing.expect(counter < total);
+}
+
+test "Threading: soft stop waits for all queued tasks to finish" {
+    t.tprint("Threading soft stop test\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    // Start worker
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+    var sctx = threading.StartCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.StartCommand(&sctx));
+    runQueue(&q);
+    w.waitStarted();
+
+    // Enqueue several tasks
+    var counter: usize = 0;
+    const Maker = CommandFactory(SleepIncCtx, execSleepInc);
+    const per_ns: u64 = 1_000_000; // 1 ms
+    const total: usize = 8;
+    var i: usize = 0;
+    while (i < total) : (i += 1) {
+        const heap_ctx = try alloc.create(SleepIncCtx);
+        heap_ctx.* = .{ .counter = &counter, .ns = per_ns };
+        const cmd = Maker.makeOwned(heap_ctx, .flaky, false, false);
+        w.enqueue(cmd);
+    }
+
+    // Issue soft stop and wait (joins internally)
+    var ssctx = threading.SoftStopCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.SoftStopCommand(&ssctx));
+    runQueue(&q);
+
+    // After soft stop join, all tasks must be completed
+    try testing.expect(w.thread == null);
+    try testing.expectEqual(total, counter);
+    try testing.expectEqual(@as(usize, 0), w.pendingCount());
+}

--- a/src/commands/threading.zig
+++ b/src/commands/threading.zig
@@ -1,0 +1,161 @@
+const std = @import("std");
+const core = @import("core.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const Worker = struct {
+    allocator: Allocator,
+
+    // Internal queue protected by mtx
+    queue: core.CommandQueue,
+    mtx: std.Thread.Mutex = .{},
+    cv: std.Thread.Condition = .{},
+
+    // Thread/flags
+    thread: ?std.Thread = null,
+    started: bool = false,
+    running: bool = false,
+    req_hard_stop: bool = false,
+    req_soft_stop: bool = false,
+
+    pub fn init(a: Allocator) Worker {
+        return .{ .allocator = a, .queue = core.CommandQueue.init(a) };
+    }
+
+    pub fn deinit(self: *Worker) void {
+        // Ensure stopped
+        _ = self.hardStopJoin() catch {};
+        // Drop any pending commands, if any
+        while (self.queue.popFront()) |cmd| {
+            if (cmd.drop) |d| d(cmd.ctx, self.allocator);
+        }
+        self.queue.deinit();
+    }
+
+    fn loopFn(self: *Worker) void {
+        self.mtx.lock();
+        self.started = true;
+        self.running = true;
+        self.cv.broadcast();
+        while (true) {
+            // Break immediately on hard stop request
+            if (self.req_hard_stop) break;
+            // Wait for work if empty
+            if (self.queue.isEmpty()) {
+                if (self.req_soft_stop) break; // stop when empty and soft stop requested
+                self.cv.wait(&self.mtx);
+                continue;
+            }
+            // Get work
+            const cmd = self.queue.popFront().?;
+            // Execute under lock; allow commands to enqueue more work safely
+            cmd.call(cmd.ctx, &self.queue) catch {};
+            if (cmd.drop) |d| d(cmd.ctx, self.allocator);
+        }
+        self.running = false;
+        self.cv.broadcast();
+        self.mtx.unlock();
+    }
+
+    pub fn start(self: *Worker) !void {
+        self.mtx.lock();
+        defer self.mtx.unlock();
+        if (self.thread != null and self.running) return error.AlreadyStarted;
+        // reset flags
+        self.req_hard_stop = false;
+        self.req_soft_stop = false;
+        self.started = false;
+        // spawn thread
+        const th = try std.Thread.spawn(.{}, loopEntry, .{self});
+        self.thread = th;
+    }
+
+    fn loopEntry(self: *Worker) void {
+        self.loopFn();
+    }
+
+    pub fn waitStarted(self: *Worker) void {
+        self.mtx.lock();
+        while (!self.started) self.cv.wait(&self.mtx);
+        self.mtx.unlock();
+    }
+
+    pub fn enqueue(self: *Worker, cmd: core.Command) void {
+        self.mtx.lock();
+        self.queue.pushBack(cmd) catch {
+            self.mtx.unlock();
+            return;
+        };
+        self.cv.broadcast();
+        self.mtx.unlock();
+    }
+
+    pub fn softStopJoin(self: *Worker) !void {
+        var to_join: ?std.Thread = null;
+        self.mtx.lock();
+        if (self.thread) |th| {
+            self.req_soft_stop = true;
+            self.cv.broadcast();
+            to_join = th;
+        }
+        self.mtx.unlock();
+        if (to_join) |th| th.join();
+        self.mtx.lock();
+        self.thread = null;
+        self.mtx.unlock();
+    }
+
+    pub fn hardStopJoin(self: *Worker) !void {
+        var to_join: ?std.Thread = null;
+        self.mtx.lock();
+        if (self.thread) |th| {
+            self.req_hard_stop = true;
+            self.cv.broadcast();
+            to_join = th;
+        }
+        self.mtx.unlock();
+        if (to_join) |th| th.join();
+        self.mtx.lock();
+        self.thread = null;
+        self.mtx.unlock();
+    }
+
+    // Testing helpers
+    pub fn pendingCount(self: *Worker) usize {
+        self.mtx.lock();
+        const n = self.queue.list.items.len;
+        self.mtx.unlock();
+        return n;
+    }
+};
+
+// ---------------- Commands to control Worker ----------------
+pub const StartCtx = struct { worker: *Worker };
+pub fn execStart(ctx: *StartCtx, _: *core.CommandQueue) !void {
+    try ctx.worker.start();
+}
+
+pub const HardStopCtx = struct { worker: *Worker };
+pub fn execHardStop(ctx: *HardStopCtx, _: *core.CommandQueue) !void {
+    try ctx.worker.hardStopJoin();
+}
+
+pub const SoftStopCtx = struct { worker: *Worker };
+pub fn execSoftStop(ctx: *SoftStopCtx, _: *core.CommandQueue) !void {
+    try ctx.worker.softStopJoin();
+}
+
+pub const ThreadingFactory = struct {
+    pub fn StartCommand(ctx: *StartCtx) core.Command {
+        const Maker = core.CommandFactory(StartCtx, execStart);
+        return Maker.make(ctx, .flaky);
+    }
+    pub fn HardStopCommand(ctx: *HardStopCtx) core.Command {
+        const Maker = core.CommandFactory(HardStopCtx, execHardStop);
+        return Maker.make(ctx, .flaky);
+    }
+    pub fn SoftStopCommand(ctx: *SoftStopCtx) core.Command {
+        const Maker = core.CommandFactory(SoftStopCtx, execSoftStop);
+        return Maker.make(ctx, .flaky);
+    }
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -10,6 +10,7 @@ pub const Rotation = @import("space/rotation.zig").Rotation;
 pub const commands = struct {
     pub const core = @import("commands/core.zig");
     pub const handlers = @import("commands/handlers.zig");
+    pub const threading = @import("commands/threading.zig");
 };
 
 // Ensure tests from split files are compiled
@@ -19,4 +20,5 @@ comptime {
     _ = @import("commands/tests_macro.zig");
     _ = @import("commands/tests_ioc.zig");
     _ = @import("commands/tests_adapter.zig");
+    _ = @import("commands/tests_threading.zig");
 }


### PR DESCRIPTION
- Implement `Worker` with thread-safe command queue and execution loop.
- Add `StartCommand`, `SoftStopCommand`, and `HardStopCommand` for worker control.
- Include execution exception handling to ensure thread stability.
- Write tests for worker behavior, including both soft and hard stop modes.
- Update `README` with explanation, usage examples, and test references.