### PR TITLE
Introduce state machine framework for `Worker` management

### DIFF
--- a/src/commands/core.zig
+++ b/src/commands/core.zig
@@ -9,6 +9,10 @@ pub const CommandTag = enum {
     retry_twice,
     flaky,
     always_fails,
+    // State machine control commands for threading.Worker
+    state_hard_stop,
+    state_move_to,
+    state_run,
 };
 
 pub const CommandFn = fn (ctx: *anyopaque, q: *CommandQueue) anyerror!void;

--- a/src/commands/tests_threading.zig
+++ b/src/commands/tests_threading.zig
@@ -140,3 +140,135 @@ test "Threading: soft stop waits for all queued tasks to finish" {
     try testing.expectEqual(total, counter);
     try testing.expectEqual(@as(usize, 0), w.pendingCount());
 }
+
+// --------------- State machine transitions ---------------
+
+test "State: HardStop command terminates worker thread" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    // Start worker
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+    var sctx = threading.StartCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.StartCommand(&sctx));
+    runQueue(&q);
+    w.waitStarted();
+
+    // Enqueue state hard stop directly into worker queue
+    w.enqueue(threading.StateFactory.HardStop());
+
+    // Wait for worker to stop and then join
+    w.waitStopped();
+    // Ensure we can join/cleanup
+    _ = w.hardStopJoin() catch {};
+    try testing.expect(w.thread == null);
+}
+
+test "State: MoveToCommand switches to MoveTo and forwards tasks" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    // Start worker
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+    var sctx = threading.StartCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.StartCommand(&sctx));
+    runQueue(&q);
+    w.waitStarted();
+
+    // Prepare external queue to forward to
+    var ext_q = CommandQueue.init(alloc);
+    defer ext_q.deinit();
+
+    // Send MoveTo state command
+    w.enqueue(threading.StateFactory.MoveTo(&ext_q));
+
+    // Enqueue a task into worker; it should be forwarded, not executed by worker
+    var counter: usize = 0;
+    const Maker = CommandFactory(IncCtx, execInc);
+    const heap_ctx = try alloc.create(IncCtx);
+    heap_ctx.* = .{ .counter = &counter };
+    const inc_cmd = Maker.makeOwned(heap_ctx, .flaky, false, false);
+    w.enqueue(inc_cmd);
+
+    // Give time to forward
+    std.Thread.sleep(1_000_000); // 1 ms
+    // At this point, counter should be 0 (not executed by worker)
+    try testing.expectEqual(@as(usize, 0), counter);
+
+    // Now drain external queue and verify it runs there
+    runQueue(&ext_q);
+    try testing.expectEqual(@as(usize, 1), counter);
+
+    // Cleanup worker
+    w.enqueue(threading.StateFactory.HardStop());
+    w.waitStopped();
+    _ = w.hardStopJoin() catch {};
+}
+
+test "State: RunCommand switches back to Normal from MoveTo" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var w = threading.Worker.init(alloc);
+    defer w.deinit();
+
+    // Start worker
+    var q = CommandQueue.init(alloc);
+    defer q.deinit();
+    var sctx = threading.StartCtx{ .worker = &w };
+    try q.pushBack(threading.ThreadingFactory.StartCommand(&sctx));
+    runQueue(&q);
+    w.waitStarted();
+
+    // External queue and enter MoveTo
+    var ext_q = CommandQueue.init(alloc);
+    defer ext_q.deinit();
+    w.enqueue(threading.StateFactory.MoveTo(&ext_q));
+
+    // Forward one task
+    var counter: usize = 0;
+    const Maker = CommandFactory(IncCtx, execInc);
+    {
+        const heap_ctx = try alloc.create(IncCtx);
+        heap_ctx.* = .{ .counter = &counter };
+        const inc_cmd = Maker.makeOwned(heap_ctx, .flaky, false, false);
+        w.enqueue(inc_cmd);
+    }
+
+    std.Thread.sleep(1_000_000); // 1 ms to forward
+    // Drain ext queue: counter should become 1
+    runQueue(&ext_q);
+    try testing.expectEqual(@as(usize, 1), counter);
+
+    // Now send Run state command to return to Normal
+    w.enqueue(threading.StateFactory.Run());
+
+    // Enqueue another task; it should execute by worker (not forwarded)
+    {
+        const heap_ctx2 = try alloc.create(IncCtx);
+        heap_ctx2.* = .{ .counter = &counter };
+        const inc_cmd2 = Maker.makeOwned(heap_ctx2, .flaky, false, false);
+        w.enqueue(inc_cmd2);
+    }
+
+    // Wait a bit and check that counter increased to 2 without draining ext queue
+    std.Thread.sleep(1_000_000); // 1 ms
+    try testing.expectEqual(@as(usize, 2), counter);
+    try testing.expect(ext_q.isEmpty());
+
+    // Cleanup
+    w.enqueue(threading.StateFactory.HardStop());
+    w.waitStopped();
+    _ = w.hardStopJoin() catch {};
+}


### PR DESCRIPTION
- Add state machine structure with function-pointer-based handlers for flexible `Worker` transitions.
- Implement `Normal`, `MoveTo`, and termination states to support advanced command processing.
- Update `Worker` initialization to include state contexts and default to `Normal` state.
- Extend threading tests to cover state machine transitions and behavior.
- Add `StateFactory` for creating state-switch commands (`HardStop`, `MoveTo`, `Run`).