### PR TITLE
Add collision detection system with neighborhood-based checks and tests

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -23,6 +23,7 @@ comptime {
     _ = @import("commands/tests_threading.zig");
     _ = @import("commands/tests_endpoint.zig");
     // Include tests from new modules
+    _ = @import("space/tests_collision.zig");
     _ = @import("jwt.zig");
     _ = @import("auth.zig");
 }

--- a/src/space/collision.zig
+++ b/src/space/collision.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const core = @import("../commands/core.zig");
+const macro = @import("../commands/macro.zig");
+const vec = @import("vector.zig");
+
+pub const CollisionError = error{};
+
+pub fn CollisionFn(comptime T: type) type {
+    return fn (a: *T, b: *T) bool;
+}
+
+pub fn RecordFn(comptime T: type) type {
+    // user_ctx can be null; implementation decides what to do
+    return fn (a: *T, b: *T, hit: bool, user_ctx: ?*anyopaque) void;
+}
+
+const CellCoord = struct {
+    i: i64,
+    j: i64,
+    pub fn fromPos(p: vec.Vec2, cell_size: f64, offset: vec.Vec2) CellCoord {
+        const x = (p.x - offset.x) / cell_size;
+        const y = (p.y - offset.y) / cell_size;
+        // floor to i64
+        const xi: i64 = @intFromFloat(std.math.floor(x));
+        const yi: i64 = @intFromFloat(std.math.floor(y));
+        return .{ .i = xi, .j = yi };
+    }
+    pub fn eql(a: CellCoord, b: CellCoord) bool {
+        return a.i == b.i and a.j == b.j;
+    }
+};
+
+// Stores neighbor lists by cell and remembers last cell for each object
+pub fn NeighborhoodSystem(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        allocator: std.mem.Allocator,
+        cell_size: f64,
+        offset: vec.Vec2,
+        by_cell: std.AutoHashMap(CellCoord, std.ArrayListUnmanaged(*T)),
+        last_cell: std.AutoHashMap(*T, CellCoord),
+
+        pub fn init(a: std.mem.Allocator, cell_size: f64, offset: vec.Vec2) Self {
+            return .{ .allocator = a, .cell_size = cell_size, .offset = offset, .by_cell = std.AutoHashMap(CellCoord, std.ArrayListUnmanaged(*T)).init(a), .last_cell = std.AutoHashMap(*T, CellCoord).init(a) };
+        }
+        pub fn deinit(self: *Self) void {
+            var it = self.by_cell.iterator();
+            while (it.next()) |kv| kv.value_ptr.*.deinit(self.allocator);
+            self.by_cell.deinit();
+            self.last_cell.deinit();
+        }
+
+        fn getOrCreateCell(self: *Self, key: CellCoord) !*std.ArrayListUnmanaged(*T) {
+            if (self.by_cell.getPtr(key)) |p| return p;
+            try self.by_cell.put(key, .{});
+            return self.by_cell.getPtr(key).?;
+        }
+
+        pub fn addObject(self: *Self, obj: *T) !void {
+            const p = try obj.getPosition();
+            const c = CellCoord.fromPos(p, self.cell_size, self.offset);
+            var list = try self.getOrCreateCell(c);
+            try list.append(self.allocator, obj);
+            try self.last_cell.put(obj, c);
+        }
+
+        pub fn removeObject(self: *Self, obj: *T) void {
+            if (self.last_cell.get(obj)) |oldc| {
+                if (self.by_cell.getPtr(oldc)) |list| {
+                    var i: usize = 0;
+                    while (i < list.items.len) : (i += 1) {
+                        if (list.items[i] == obj) {
+                            _ = list.orderedRemove(i);
+                            break;
+                        }
+                    }
+                }
+                _ = self.last_cell.remove(obj);
+            }
+        }
+
+        // Update cell membership for obj and return the neighbor slice pointer for the new cell
+        pub fn updateMembership(self: *Self, obj: *T) ![]*T {
+            const p = try obj.getPosition();
+            const newc = CellCoord.fromPos(p, self.cell_size, self.offset);
+            const oldc_opt = self.last_cell.get(obj);
+            if (oldc_opt) |oldc| {
+                if (!CellCoord.eql(oldc, newc)) {
+                    // move between lists
+                    if (self.by_cell.getPtr(oldc)) |old_list| {
+                        var i: usize = 0;
+                        while (i < old_list.items.len) : (i += 1) {
+                            if (old_list.items[i] == obj) {
+                                _ = old_list.orderedRemove(i);
+                                break;
+                            }
+                        }
+                    }
+                    var new_list = try self.getOrCreateCell(newc);
+                    try new_list.append(self.allocator, obj);
+                    try self.last_cell.put(obj, newc);
+                }
+            } else {
+                // first time seen
+                var list = try self.getOrCreateCell(newc);
+                try list.append(self.allocator, obj);
+                try self.last_cell.put(obj, newc);
+            }
+            // return slice of objects for current cell
+            const curc = self.last_cell.get(obj).?;
+            const cur = self.by_cell.getPtr(curc).?;
+            return cur.items;
+        }
+    };
+}
+
+// Command to check a single pair and record using callbacks
+pub fn PairCheckCtx(comptime T: type) type {
+    return struct {
+        a: *T,
+        b: *T,
+        check: *const CollisionFn(T),
+        record: *const RecordFn(T),
+        user_ctx: ?*anyopaque = null,
+    };
+}
+
+pub fn execPairCheck(comptime T: type, ctx: *PairCheckCtx(T), _: *core.CommandQueue) anyerror!void {
+    const hit = ctx.check(ctx.a, ctx.b);
+    ctx.record(ctx.a, ctx.b, hit, ctx.user_ctx);
+}
+
+// Build macro of checks for obj against all others in same cell (skipping self)
+pub fn buildCellMacro(
+    comptime T: type,
+    allocator: std.mem.Allocator,
+    obj: *T,
+    neighbors: []*T,
+    check: *const CollisionFn(T),
+    record: *const RecordFn(T),
+    user_ctx: ?*anyopaque,
+) !core.Command {
+    // create commands for each neighbor except self
+    var items = std.ArrayList(core.Command).init(allocator);
+    errdefer items.deinit();
+
+    const Exec = struct {
+        fn run(ctx: *PairCheckCtx(T), q: *core.CommandQueue) anyerror!void {
+            return execPairCheck(T, ctx, q);
+        }
+    }.run;
+    const Maker = core.CommandFactory(PairCheckCtx(T), Exec);
+
+    for (neighbors) |other| {
+        if (other == obj) continue;
+        const c = try allocator.create(PairCheckCtx(T));
+        c.* = .{ .a = obj, .b = other, .check = check, .record = record, .user_ctx = user_ctx };
+        const cmd = Maker.makeOwned(c, .flaky, false, false);
+        try items.append(cmd);
+    }
+
+    // Build an owned macro with custom drop that frees inner commands and slice
+    const CollMacroCtx = struct {
+        allocator: std.mem.Allocator,
+        items: []const core.Command,
+    };
+    const collThunk = struct {
+        fn call(raw: *anyopaque, q: *core.CommandQueue) anyerror!void {
+            const ctx: *CollMacroCtx = @ptrCast(@alignCast(raw));
+            // Execute like macro.execMacro
+            for (ctx.items) |c| {
+                try c.call(c.ctx, q);
+            }
+        }
+    }.call;
+    const collDrop = struct {
+        fn drop(raw: *anyopaque, a: std.mem.Allocator) void {
+            const ctx: *CollMacroCtx = @ptrCast(@alignCast(raw));
+            // Drop inner commands then free the slice
+            for (ctx.items) |c| {
+                if (c.drop) |d| d(c.ctx, a);
+            }
+            a.free(ctx.items);
+            a.destroy(ctx);
+        }
+    }.drop;
+
+    const mctx = try allocator.create(CollMacroCtx);
+    mctx.* = .{ .allocator = allocator, .items = try items.toOwnedSlice() };
+    return .{ .ctx = mctx, .call = collThunk, .drop = collDrop, .tag = .flaky, .is_wrapper = false, .is_log = false, .retry_stage = 0 };
+}
+
+// Chain of responsibility over an arbitrary number of neighborhood systems
+pub fn NeighborhoodChain(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        allocator: std.mem.Allocator,
+        systems: []NeighborhoodSystem(T),
+
+        pub fn init(a: std.mem.Allocator, systems: []NeighborhoodSystem(T)) Self {
+            return .{ .allocator = a, .systems = systems };
+        }
+    };
+}
+
+// Update command ctx: for a moving object, update membership across all systems and place macros into given bridges
+pub fn UpdateCtx(comptime T: type) type {
+    return struct {
+        chain: *NeighborhoodChain(T),
+        obj: *T,
+        // One BridgeCtx per system to be updated (length must equal chain.systems.len)
+        bridges: []*macro.BridgeCtx,
+        check: *const CollisionFn(T),
+        record: *const RecordFn(T),
+        user_ctx: ?*anyopaque = null,
+    };
+}
+
+pub fn execUpdate(comptime T: type, ctx: *UpdateCtx(T), q: *core.CommandQueue) anyerror!void {
+    _ = q;
+    const n = ctx.chain.systems.len;
+    std.debug.assert(n == ctx.bridges.len);
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        var sys_ptr: *NeighborhoodSystem(T) = &ctx.chain.systems[i];
+        const neighbors = try sys_ptr.updateMembership(ctx.obj);
+        // build macro and store into bridge.inner (replace previous)
+        const new_macro = try buildCellMacro(T, ctx.chain.allocator, ctx.obj, neighbors, ctx.check, ctx.record, ctx.user_ctx);
+        var br = ctx.bridges[i];
+        // drop previous command if owned
+        if (br.inner.drop) |d| d(br.inner.ctx, ctx.chain.allocator);
+        br.inner = new_macro;
+    }
+}

--- a/src/space/tests_collision.zig
+++ b/src/space/tests_collision.zig
@@ -1,0 +1,346 @@
+const std = @import("std");
+const testing = std.testing;
+const t = @import("../utils/tests/helpers.zig");
+const vec = @import("vector.zig");
+const core = @import("../commands/core.zig");
+const macro = @import("../commands/macro.zig");
+const coll = @import("collision.zig");
+
+const CommandFactory = core.CommandFactory;
+
+// Simple object used in tests
+const Obj = struct {
+    pos: vec.Vec2,
+    pub fn getPosition(self: *Obj) !vec.Vec2 {
+        return self.pos;
+    }
+};
+
+// Recorder for counting performed checks when predicate passes
+const Recorder = struct { count: usize = 0 };
+
+fn alwaysTrue(_: *Obj, _: *Obj) bool {
+    return true;
+}
+
+fn recordCount(_: *Obj, _: *Obj, hit: bool, user_ctx: ?*anyopaque) void {
+    if (!hit) return;
+    const pr: *Recorder = @ptrCast(@alignCast(user_ctx.?));
+    pr.count += 1;
+}
+
+fn execUpdate_O(ctx: *coll.UpdateCtx(Obj), q: *core.CommandQueue) anyerror!void {
+    return coll.execUpdate(Obj, ctx, q);
+}
+
+fn execBridge(ctx: *macro.BridgeCtx, q: *core.CommandQueue) anyerror!void {
+    return macro.execBridge(ctx, q);
+}
+
+test "Collision: single system list formation and macro creation" {
+    t.tprint("Collision test: single system membership and macro\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    // objects
+    var o1 = Obj{ .pos = .{ .x = 1, .y = 1 } }; // moving
+    var o2 = Obj{ .pos = .{ .x = 2, .y = 2 } }; // same cell
+    var o3 = Obj{ .pos = .{ .x = 15, .y = 0 } }; // different cell
+
+    // systems
+    var systems = [_]coll.NeighborhoodSystem(Obj){coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 0, .y = 0 })};
+    defer systems[0].deinit();
+
+    // add static objects to system 0
+    try systems[0].addObject(&o2);
+    try systems[0].addObject(&o3);
+
+    var chain = coll.NeighborhoodChain(Obj).init(A, systems[0..]);
+
+    // prepare a bridge for this system
+    var noop = macro.NoOpCtx{};
+    var bridge = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop, .flaky) };
+    var bridges = [_]*macro.BridgeCtx{&bridge};
+
+    var rec = Recorder{ .count = 0 };
+
+    // Build update command ctx
+    var uctx = coll.UpdateCtx(Obj){ .chain = &chain, .obj = &o1, .bridges = bridges[0..], .check = &alwaysTrue, .record = &recordCount, .user_ctx = &rec };
+    const UM = CommandFactory(coll.UpdateCtx(Obj), execUpdate_O);
+    var ucmd = UM.make(&uctx, .flaky);
+
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    try ucmd.call(ucmd.ctx, &q);
+
+    // Execute bridge: should perform 1 check with o2
+    const BM = CommandFactory(macro.BridgeCtx, execBridge);
+    const bcmd = BM.make(&bridge, .flaky);
+    try bcmd.call(bcmd.ctx, &q);
+
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    // Move o1 to new cell with o3 and update again
+    o1.pos = .{ .x = 16, .y = 0 };
+    rec.count = 0;
+    try ucmd.call(ucmd.ctx, &q);
+    try bcmd.call(bcmd.ctx, &q);
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    // cleanup: drop bridge's inner macro
+    if (bridge.inner.drop) |d| d(bridge.inner.ctx, A);
+}
+
+// Boundary test with two offset systems
+fn execUpdate2_O(ctx: *coll.UpdateCtx(Obj), q: *core.CommandQueue) anyerror!void {
+    return coll.execUpdate(Obj, ctx, q);
+}
+
+test "Collision: dual offset systems cover boundary case" {
+    t.tprint("Collision test: dual systems boundary coverage\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    // objects
+    var a = Obj{ .pos = .{ .x = 9.1, .y = 0 } }; // moving near boundary
+    var b = Obj{ .pos = .{ .x = 10.2, .y = 0 } }; // on the other side
+
+    var systems = [_]coll.NeighborhoodSystem(Obj){
+        coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 0, .y = 0 }),
+        coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 5, .y = 5 }),
+    };
+    defer {
+        systems[0].deinit();
+        systems[1].deinit();
+    }
+
+    // add static b to both systems
+    try systems[0].addObject(&b);
+    try systems[1].addObject(&b);
+
+    var chain = coll.NeighborhoodChain(Obj).init(A, systems[0..]);
+
+    // two bridges
+    var noop0 = macro.NoOpCtx{};
+    var noop1 = macro.NoOpCtx{};
+    var bridge0 = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop0, .flaky) };
+    var bridge1 = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop1, .flaky) };
+    var bridges = [_]*macro.BridgeCtx{ &bridge0, &bridge1 };
+
+    var rec = Recorder{ .count = 0 };
+
+    var uctx = coll.UpdateCtx(Obj){ .chain = &chain, .obj = &a, .bridges = bridges[0..], .check = &alwaysTrue, .record = &recordCount, .user_ctx = &rec };
+    const UM = CommandFactory(coll.UpdateCtx(Obj), execUpdate2_O);
+    var ucmd = UM.make(&uctx, .flaky);
+
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    try ucmd.call(ucmd.ctx, &q);
+
+    // Execute bridge for system 0: should be 0 checks (different cells)
+    const BM = CommandFactory(macro.BridgeCtx, execBridge);
+    const b0 = BM.make(&bridge0, .flaky);
+    rec.count = 0;
+    try b0.call(b0.ctx, &q);
+    try testing.expectEqual(@as(usize, 0), rec.count);
+
+    // Execute bridge for system 1: should be 1 check (same shifted cell)
+    const b1 = BM.make(&bridge1, .flaky);
+    rec.count = 0;
+    try b1.call(b1.ctx, &q);
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    // cleanup
+    if (bridge0.inner.drop) |d| d(bridge0.inner.ctx, A);
+    if (bridge1.inner.drop) |d| d(bridge1.inner.ctx, A);
+}
+
+fn predNegX(_: *Obj, b: *Obj) bool {
+    return b.pos.x < 0;
+}
+
+const HM = struct { total: usize = 0, misses: usize = 0 };
+fn recordHM(_: *Obj, _: *Obj, hit: bool, user_ctx: ?*anyopaque) void {
+    const pr: *HM = @ptrCast(@alignCast(user_ctx.?));
+    pr.total += 1;
+    if (!hit) pr.misses += 1;
+}
+
+test "Collision: buildCellMacro skips self and respects predicate" {
+    t.tprint("Collision test: buildCellMacro skip self + predicate\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    var obj = Obj{ .pos = .{ .x = 0, .y = 0 } };
+    var n1 = Obj{ .pos = .{ .x = -1, .y = 0 } }; // hit (neg x)
+    var n2 = Obj{ .pos = .{ .x = 1, .y = 0 } }; // miss
+
+    var neighbors = [_]*Obj{ &obj, &n1, &n2 };
+
+    var rec = Recorder{ .count = 0 };
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    const cmd = try coll.buildCellMacro(Obj, A, &obj, neighbors[0..], &predNegX, &recordCount, &rec);
+    defer if (cmd.drop) |d| d(cmd.ctx, A);
+    try cmd.call(cmd.ctx, &q);
+
+    try testing.expectEqual(@as(usize, 1), rec.count);
+}
+
+test "Collision: macro with only self does nothing" {
+    t.tprint("Collision test: macro with only self\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    var obj = Obj{ .pos = .{ .x = 0, .y = 0 } };
+    var neighbors = [_]*Obj{&obj};
+
+    var rec = Recorder{ .count = 0 };
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    const cmd = try coll.buildCellMacro(Obj, A, &obj, neighbors[0..], &alwaysTrue, &recordCount, &rec);
+    defer if (cmd.drop) |d| d(cmd.ctx, A);
+    try cmd.call(cmd.ctx, &q);
+
+    try testing.expectEqual(@as(usize, 0), rec.count);
+}
+
+test "Collision: removeObject reduces neighbor checks and same-cell update persists" {
+    t.tprint("Collision test: removeObject + same-cell update\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    var a = Obj{ .pos = .{ .x = 1, .y = 1 } };
+    var b = Obj{ .pos = .{ .x = 2, .y = 2 } };
+    var c = Obj{ .pos = .{ .x = 3, .y = 3 } };
+
+    var sys = coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 0, .y = 0 });
+    defer sys.deinit();
+    try sys.addObject(&b);
+    try sys.addObject(&c);
+
+    var systems = [_]coll.NeighborhoodSystem(Obj){sys};
+    var chain = coll.NeighborhoodChain(Obj).init(A, systems[0..]);
+
+    var noop = macro.NoOpCtx{};
+    var bridge = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop, .flaky) };
+    var bridges = [_]*macro.BridgeCtx{&bridge};
+
+    var rec = Recorder{ .count = 0 };
+    var uctx = coll.UpdateCtx(Obj){ .chain = &chain, .obj = &a, .bridges = bridges[0..], .check = &alwaysTrue, .record = &recordCount, .user_ctx = &rec };
+    const UM = CommandFactory(coll.UpdateCtx(Obj), execUpdate_O);
+    var ucmd = UM.make(&uctx, .flaky);
+
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    // Initial: 2 neighbors
+    try ucmd.call(ucmd.ctx, &q);
+    const BM = CommandFactory(macro.BridgeCtx, execBridge);
+    const bcmd = BM.make(&bridge, .flaky);
+    try bcmd.call(bcmd.ctx, &q);
+    try testing.expectEqual(@as(usize, 2), rec.count);
+
+    // Remove one neighbor and update again
+    rec.count = 0;
+    sys.removeObject(&c);
+    try ucmd.call(ucmd.ctx, &q);
+    try bcmd.call(bcmd.ctx, &q);
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    // Move within same cell; still 1 neighbor
+    rec.count = 0;
+    a.pos = .{ .x = 1.5, .y = 1.5 };
+    try ucmd.call(ucmd.ctx, &q);
+    try bcmd.call(bcmd.ctx, &q);
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    if (bridge.inner.drop) |d| d(bridge.inner.ctx, A);
+}
+
+test "Collision: negative coordinates with shifted offset" {
+    t.tprint("Collision test: negative coords + shifted offset\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    var a = Obj{ .pos = .{ .x = -1, .y = 0 } };
+    var b = Obj{ .pos = .{ .x = 3, .y = 0 } };
+
+    var systems = [_]coll.NeighborhoodSystem(Obj){
+        coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 0, .y = 0 }),
+        coll.NeighborhoodSystem(Obj).init(A, 10, .{ .x = 5, .y = 5 }),
+    };
+    defer {
+        systems[0].deinit();
+        systems[1].deinit();
+    }
+
+    try systems[0].addObject(&b);
+    try systems[1].addObject(&b);
+
+    var chain = coll.NeighborhoodChain(Obj).init(A, systems[0..]);
+
+    var noop0 = macro.NoOpCtx{};
+    var noop1 = macro.NoOpCtx{};
+    var bridge0 = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop0, .flaky) };
+    var bridge1 = macro.BridgeCtx{ .inner = CommandFactory(macro.NoOpCtx, macro.execNoOp).make(&noop1, .flaky) };
+    var bridges = [_]*macro.BridgeCtx{ &bridge0, &bridge1 };
+
+    var rec = Recorder{ .count = 0 };
+    var uctx = coll.UpdateCtx(Obj){ .chain = &chain, .obj = &a, .bridges = bridges[0..], .check = &alwaysTrue, .record = &recordCount, .user_ctx = &rec };
+    const UM = CommandFactory(coll.UpdateCtx(Obj), execUpdate2_O);
+    var ucmd = UM.make(&uctx, .flaky);
+
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    try ucmd.call(ucmd.ctx, &q);
+
+    const BM = CommandFactory(macro.BridgeCtx, execBridge);
+    const b0 = BM.make(&bridge0, .flaky);
+    const b1 = BM.make(&bridge1, .flaky);
+
+    rec.count = 0;
+    try b0.call(b0.ctx, &q);
+    try testing.expectEqual(@as(usize, 0), rec.count);
+
+    rec.count = 0;
+    try b1.call(b1.ctx, &q);
+    try testing.expectEqual(@as(usize, 1), rec.count);
+
+    if (bridge0.inner.drop) |d| d(bridge0.inner.ctx, A);
+    if (bridge1.inner.drop) |d| d(bridge1.inner.ctx, A);
+}
+
+test "Collision: record is invoked on miss (hit=false)" {
+    t.tprint("Collision test: record miss path\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const A = gpa.allocator();
+
+    var obj = Obj{ .pos = .{ .x = 0, .y = 0 } };
+    var n = Obj{ .pos = .{ .x = 1, .y = 0 } }; // not negative
+
+    var neighbors = [_]*Obj{ &obj, &n };
+
+    var hm = HM{ .total = 0, .misses = 0 };
+    var q = core.CommandQueue.init(A);
+    defer q.deinit();
+
+    const cmd = try coll.buildCellMacro(Obj, A, &obj, neighbors[0..], &predNegX, &recordHM, &hm);
+    defer if (cmd.drop) |d| d(cmd.ctx, A);
+    try cmd.call(cmd.ctx, &q);
+
+    try testing.expectEqual(@as(usize, 1), hm.total);
+    try testing.expectEqual(@as(usize, 1), hm.misses);
+}


### PR DESCRIPTION
- Implement a modular `NeighborhoodSystem` for spatial partitioning and neighbor management.
- Add `CollisionFn` and `RecordFn` for custom collision predicates and result recording.
- Introduce macro-based neighbor check execution for efficiency.
- Implement extensive tests for single and dual systems, cell membership updates, and predicate respects.
- Register collision tests in the build system.