### PR TITLE
Interpreter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,6 @@ jobs:
 
       - name: Upload Trivy scan results
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
- Add ownership management and per-player scoped operations
- Introduce `GameRegistry` ownership API (`setOwner`/`getOwner`) for associating in-game objects with users.
- Enforce ownership via `authorizeOwnership` to restrict object control to owners.
- Extend `InterpretFactory` with user-specific operations using per-player scopes.
- Update HTTP endpoint to apply ownership checks and dynamic scope resolution at runtime.
- Add comprehensive tests for ownership enforcement, user-specific operations, and IoC-based command routing.
- Enhance `README.md` with detailed usage notes and examples for ownership and scoped operations.